### PR TITLE
Add support for external target directories

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2018-11-21 Olof Kindgren <olof.kindgren@gmail.com>
+    * Added support for using external target directories with $TARGETDIR
+
 2018-11-21 Neel Gala <neelgala@incoresemi.com>
    	* riscv-test-suite/rv_/references/_.reference_output: changed signature 
 	  format for all tests to include only 4-bytes per line starting with the

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ endif
 export ROOTDIR  = $(shell pwd)
 export WORK     = $(ROOTDIR)/work
 export SUITEDIR = $(ROOTDIR)/riscv-test-suite/$(RISCV_ISA)
+export TARGETDIR ?= $(ROOTDIR)/riscv-target
 
 default: $(DEFAULT_TARGET)
 
@@ -50,7 +51,7 @@ simulate:
 		RISCV_DEVICE=$(RISCV_DEVICE) \
 		RISCV_PREFIX=$(RISCV_PREFIX) \
 		run -C $(SUITEDIR)
-	
+
 verify:
 	riscv-test-env/verify.sh
 
@@ -67,4 +68,4 @@ help:
 	@echo "RISCV_DEVICE='rv32i|rv32im|...'"
 	@echo "RISCV_ISA=$(RISCV_ISA_OPT)"
 	@echo "make all_variant // all combinations"
-	
+

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,7 @@
+2018-11-21 Olof Kindgren <olof.kindgren@gmail.com>
+
+	* README.adoc (Repository structure) Added documentation for the $TARGETDIR environmental variable
+
 2018-11-21  Neel Gala  <neelgala@incoresemi.com>
 	* README.adoc: Added new signature format spec.
 

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -460,7 +460,7 @@ The top level directory contains a `README.md` file giving an overview of the pr
 
 `doc`:: All the documentation for the project, written using _AsciiDoc_.
 
-`riscv-target`:: Contains a further subdirectory for each target, within which are placed the `compliance_io.h` header for that target and a `device` directory for all the devices of that target.
+`riscv-target`:: Contains a further subdirectory for each target, within which are placed the `compliance_io.h` header for that target and a `device` directory for all the devices of that target. If the `$TARGETDIR` environment variable is set to another directory, the scripts will search this directory for targets instead.
 
 `riscv-test-env`:: This contains headers common to all environments, and then a directory for each TVM variant, with `link.ld` linker script and `riscv_test.h` header.
 

--- a/riscv-target/Codasip-simulator/device/rv32i/Makefile.include
+++ b/riscv-target/Codasip-simulator/device/rv32i/Makefile.include
@@ -19,5 +19,5 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		$$< -o $(work_dir_isa)/$$@

--- a/riscv-target/riscvOVPsim/device/rv32i/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32i/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32im/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32im/Makefile.include
@@ -34,7 +34,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32imc/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32imc/Makefile.include
@@ -34,7 +34,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
     $$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump; \

--- a/riscv-target/riscvOVPsim/device/rv32mi/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32mi/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32si/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32si/Makefile.include
@@ -38,7 +38,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32ua/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32ua/Makefile.include
@@ -34,7 +34,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32uc/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32uc/Makefile.include
@@ -36,7 +36,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32ud/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32ud/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32uf/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32uf/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv32ui/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv32ui/Makefile.include
@@ -38,7 +38,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv64i/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/riscvOVPsim/device/rv64im/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64im/Makefile.include
@@ -33,7 +33,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32i/Makefile.include
+++ b/riscv-target/spike/device/rv32i/Makefile.include
@@ -21,7 +21,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32im/Makefile.include
+++ b/riscv-target/spike/device/rv32im/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32imc/Makefile.include
+++ b/riscv-target/spike/device/rv32imc/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32mi/Makefile.include
+++ b/riscv-target/spike/device/rv32mi/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32si/Makefile.include
+++ b/riscv-target/spike/device/rv32si/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32ua/Makefile.include
+++ b/riscv-target/spike/device/rv32ua/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32uc/Makefile.include
+++ b/riscv-target/spike/device/rv32uc/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32ud/Makefile.include
+++ b/riscv-target/spike/device/rv32ud/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32uf/Makefile.include
+++ b/riscv-target/spike/device/rv32uf/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv32ui/Makefile.include
+++ b/riscv-target/spike/device/rv32ui/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv64i/Makefile.include
+++ b/riscv-target/spike/device/rv64i/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-target/spike/device/rv64im/Makefile.include
+++ b/riscv-target/spike/device/rv64im/Makefile.include
@@ -20,7 +20,7 @@ COMPILE_TARGET=\
 	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
 		-I$(ROOTDIR)/riscv-test-env/ \
 		-I$(ROOTDIR)/riscv-test-env/p/ \
-		-I$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
 		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
 		-o $(work_dir_isa)/$$@; \
 	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump

--- a/riscv-test-suite/rv32i/Makefile
+++ b/riscv-test-suite/rv32i/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32im/Makefile
+++ b/riscv-test-suite/rv32im/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32imc/Makefile
+++ b/riscv-test-suite/rv32imc/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32mi/Makefile
+++ b/riscv-test-suite/rv32mi/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32si/Makefile
+++ b/riscv-test-suite/rv32si/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32ua/Makefile
+++ b/riscv-test-suite/rv32ua/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32uc/Makefile
+++ b/riscv-test-suite/rv32uc/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32ud/Makefile
+++ b/riscv-test-suite/rv32ud/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32uf/Makefile
+++ b/riscv-test-suite/rv32uf/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv32ui/Makefile
+++ b/riscv-test-suite/rv32ui/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv64i/Makefile
+++ b/riscv-test-suite/rv64i/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif

--- a/riscv-test-suite/rv64im/Makefile
+++ b/riscv-test-suite/rv64im/Makefile
@@ -17,7 +17,7 @@ default: all
 
 vpath %.S $(act_dir)
 
-INCLUDE=$(ROOTDIR)/riscv-target/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
+INCLUDE=$(TARGETDIR)/$(RISCV_TARGET)/device/$(RISCV_DEVICE)/Makefile.include
 ifeq ($(wildcard $(INCLUDE)),)
     $(error Cannot find '$(INCLUDE)`. Check that RISCV_TARGET and RISCV_DEVICE are set correctly.)
 endif


### PR DESCRIPTION
This adds support for setting the TARGETDIR environment variable to use
an external root directory for the targets, to allow keeping the target files
close to the core instead of forking this repo for every new user.