### PR TITLE
breakpoint.S fix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 
 2019-02-05 Deborah Soung <debs@sifive.com>
     * [Issue #33] fixing rv32si/ma_fetch.S test
+    * [Issue #32] fixing breakpoint test
 
 2019-02-01 Lee Moore <moore@imperas.com>
     * updated Infrastructure macros to support non-volatile registers

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,6 @@
 2019-02-05  Deborah Soung  <debs@sifive.com>
 	* README.adoc: Update documentation for rocket chip as target (fixed rv32si/ma_fetch.S).
+	* README.adoc: Update documentation for rocket chip as target (fixed breakpoint.S).
 
 2019-01-29  Deborah Soung  <debs@sifive.com>
 	* README.adoc: Documentation for rocket chip as target.

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -361,7 +361,7 @@ Additional environment variables:
 
 Before running the compliance test, make sure that the correct emulator is built, following the link:https://github.com/freechipsproject/rocket-chip#emulator[instructions in the Rocket Chip repository].
 
-**Note**: Rocket Chip's `DefaultRV32Config` is currently failing the following tests — link:https://github.com/riscv/riscv-compliance/issues/31[rv32i/I-MISALIGN_JMP-01.S], link:https://github.com/riscv/riscv-compliance/issues/32[rv32mi/breakpoint.S].
+**Note**: Rocket Chip's `DefaultRV32Config` is currently failing the following test — link:https://github.com/riscv/riscv-compliance/issues/31[rv32i/I-MISALIGN_JMP-01.S].
 
 === SiFive Freedom Unleashed 540 board (tbd)
 

--- a/riscv-test-suite/rv32mi/rv64mi/breakpoint.S
+++ b/riscv-test-suite/rv32mi/rv64mi/breakpoint.S
@@ -22,13 +22,13 @@ RV_COMPLIANCE_CODE_BEGIN
   # Skip tselect if hard-wired.
   csrw tselect, x0
   csrr a1, tselect
-  bne x0, a1, pass
+  bne x0, a1, sign_pass
 
   # Make sure there's a breakpoint there.
   csrr a0, tdata1
   srli a0, a0, __riscv_xlen - 4
   li a1, 2
-  bne a0, a1, pass
+  bne a0, a1, sign_pass
 
   la a2, 1f
   csrw tdata2, a2
@@ -94,13 +94,13 @@ RV_COMPLIANCE_CODE_BEGIN
   li a0, 1
   csrw tselect, a0
   csrr a1, tselect
-  bne a0, a1, pass
+  bne a0, a1, sign_pass
 
   # Make sure there's a breakpoint there.
   csrr a0, tdata1
   srli a0, a0, __riscv_xlen - 4
   li a1, 2
-  bne a0, a1, pass
+  bne a0, a1, sign_pass
 
   li a0, MCONTROL_M | MCONTROL_LOAD
   csrw tdata1, a0
@@ -125,6 +125,25 @@ RV_COMPLIANCE_CODE_BEGIN
 
 2:
   TEST_PASSFAIL
+
+sign_pass:
+  li TESTNUM, 3
+  SWSIG(3, TESTNUM)
+  li TESTNUM, 4
+  SWSIG(4, TESTNUM)
+  li TESTNUM, 5
+  SWSIG(5, TESTNUM)
+  li TESTNUM, 6
+  SWSIG(6, TESTNUM)
+  li TESTNUM, 7
+  SWSIG(7, TESTNUM)
+  li TESTNUM, 8
+  SWSIG(8, TESTNUM)
+  li TESTNUM, 10
+  SWSIG(10, TESTNUM)
+  li TESTNUM, 11
+  SWSIG(11, TESTNUM)
+  j pass
 
   .align 2
   .global mtvec_handler


### PR DESCRIPTION
**Goal:** solve issue #32

**Changes:** Instead of going to the `pass` label if a breakpoint does not exist, branch to `sign_pass`, which writes the signature, then goes to the `pass` label. The end result is that the signature will match even if breakpoints are not implemented.