### PR TITLE
Target RI5CY

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2019-08-29 Robert Balas <balasr@iis.ee.ethz.ch>
+    * Added support for using RI5CY as a target.
+    * Added subdirectory riscv-target/ri5cy
+
 2019-08-08 Lee Moore <moore@imperas.com>
     * Added support for lowRISC/ibex RTL as a target using Verilator.
       In conjunction with Philipp Wagner of lowRISC phw@lowrisc.org

--- a/riscv-target/ri5cy/README.md
+++ b/riscv-target/ri5cy/README.md
@@ -1,11 +1,12 @@
 # Running the compliance tests with RI5CY
 Build RI5CY's core testbench by navigating to `riscv/tb/core` and calling `make
-vsim-all`. Note that only questasim was tested, but with some work other
-simulators can be used too.
+vsim-all` or if you prefer verilator `make verilate`.
 
 Set `TARGET_SIM` by providing the `vsim` executable and the work directory of
 the compiled model of RI5CY e.g.
 `export TARGET_SIM=vsim -work RI5CY_REPO/tb/core/work`
+or point `TARGET_SIM` to the compiled verilator testbench e.g.
+`export TARGET_SIM=RI5CY_REPO/tb/core/testbench_verilator`
 
 Now set the following variables:
 ```

--- a/riscv-target/ri5cy/README.md
+++ b/riscv-target/ri5cy/README.md
@@ -1,0 +1,20 @@
+# Running the compliance tests with RI5CY
+Build RI5CY's core testbench by navigating to `riscv/tb/core` and calling `make
+vsim-all`. Note that only questasim was tested, but with some work other
+simulators can be used too.
+
+Set `TARGET_SIM` by providing the `vsim` executable and the work directory of
+the compiled model of RI5CY e.g.
+`export TARGET_SIM=vsim -work RI5CY_REPO/tb/core/work`
+
+Now set the following variables:
+```
+export RISCV_PREFIX=riscv32-unknown-elf-
+export RISCV_TARGET=ri5cy
+export RISCV_DEVICE=rv32imc
+```
+
+You are now ready to run the tests. The following are supported:
+* `make RISCV_ISA=rv32i`
+* `make RISCV_ISA=rv32im`
+* `make RISCV_ISA=rv32imc`

--- a/riscv-target/ri5cy/compliance_io.h
+++ b/riscv-target/ri5cy/compliance_io.h
@@ -1,0 +1,242 @@
+// RISC-V Compliance IO Test Header File
+
+/*
+ * Copyright (c) 2005-2018 Imperas Software Ltd., www.imperas.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+//
+// In general the following registers are reserved
+// ra, a0, t0, t1
+// x1, x10 x5, x6
+// new reserve x31
+//
+
+#ifndef _COMPLIANCE_IO_H
+#define _COMPLIANCE_IO_H
+
+/* #define RVTEST_IO_QUIET */
+
+//-----------------------------------------------------------------------
+// RV IO Macros (Character transfer by custom instruction)
+//-----------------------------------------------------------------------
+#define STRINGIFY(x) #x
+#define TOSTRING(x)  STRINGIFY(x)
+
+#define RVTEST_CUSTOM1 0x10000000
+
+#ifdef RVTEST_IO_QUIET
+
+#define RVTEST_IO_INIT
+#define RVTEST_IO_WRITE_STR(_SP, _STR)
+#define RVTEST_IO_CHECK()
+#define RVTEST_IO_ASSERT_GPR_EQ(_SP, _R, _I)
+#define RVTEST_IO_ASSERT_SFPR_EQ(_F, _R, _I)
+#define RVTEST_IO_ASSERT_DFPR_EQ(_D, _R, _I)
+
+#else
+
+#define RSIZE 4
+// _SP = (volatile register)
+#define LOCAL_IO_PUSH(_SP)                                              \
+    la      _SP,  begin_regstate;                                       \
+    sw      x1,   (1*RSIZE)(_SP);                                       \
+    sw      x5,   (5*RSIZE)(_SP);                                       \
+    sw      x6,   (6*RSIZE)(_SP);                                       \
+    sw      x8,   (8*RSIZE)(_SP);                                       \
+    sw      x10,  (10*RSIZE)(_SP);
+
+// _SP = (volatile register)
+#define LOCAL_IO_POP(_SP)                                               \
+    la      _SP,   begin_regstate;                                      \
+    lw      x1,   (1*RSIZE)(_SP);                                       \
+    lw      x5,   (5*RSIZE)(_SP);                                       \
+    lw      x6,   (6*RSIZE)(_SP);                                       \
+    lw      x8,   (8*RSIZE)(_SP);                                       \
+    lw      x10,  (10*RSIZE)(_SP);
+
+#define LOCAL_IO_WRITE_GPR(_R)                                          \
+    mv          a0, _R;                                                 \
+    jal         FN_WriteA0;
+
+#define LOCAL_IO_WRITE_FPR(_F)                                          \
+    fmv.x.s     a0, _F;                                                 \
+    jal         FN_WriteA0;
+
+#define LOCAL_IO_WRITE_DFPR(_V1, _V2)                                   \
+    mv          a0, _V1;                                                \
+    jal         FN_WriteA0;						\
+    mv          a0, _V2;						\
+    jal         FN_WriteA0;						\
+
+#define LOCAL_IO_PUTC(_R)                                               \
+    la          t3, RVTEST_CUSTOM1;					\
+    sw          _R, (0)(t3);						\
+
+#define RVTEST_IO_INIT
+
+// Assertion violation: file file.c, line 1234: (expr)
+// _SP = (volatile register)
+// _R = GPR
+// _I = Immediate
+#define RVTEST_IO_ASSERT_GPR_EQ(_SP, _R, _I)                            \
+    LOCAL_IO_PUSH(_SP)                                                  \
+    mv          s0, _R;                                                 \
+    li          t0, _I;                                                 \
+    beq         s0, t0, 20002f;                                         \
+    LOCAL_IO_WRITE_STR("Assertion violation: file ");                   \
+    LOCAL_IO_WRITE_STR(__FILE__);                                       \
+    LOCAL_IO_WRITE_STR(", line ");                                      \
+    LOCAL_IO_WRITE_STR(TOSTRING(__LINE__));                             \
+    LOCAL_IO_WRITE_STR(": ");                                           \
+    LOCAL_IO_WRITE_STR(# _R);                                           \
+    LOCAL_IO_WRITE_STR("(");                                            \
+    LOCAL_IO_WRITE_GPR(s0);                                             \
+    LOCAL_IO_WRITE_STR(") != ");                                        \
+    LOCAL_IO_WRITE_STR(# _I);                                           \
+    LOCAL_IO_WRITE_STR("\n");                                           \
+    li TESTNUM, 100;                                                    \
+    RVTEST_FAIL;                                                        \
+20002:                                                                  \
+    LOCAL_IO_POP(_SP)
+
+// _F = FPR
+// _C = GPR
+// _I = Immediate
+#define RVTEST_IO_ASSERT_SFPR_EQ(_F, _C, _I)                            \
+    fmv.x.s     t0, _F;                                                 \
+    beq         _C, t0, 20003f;                                         \
+    LOCAL_IO_WRITE_STR("Assertion violation: file ");                   \
+    LOCAL_IO_WRITE_STR(__FILE__);                                       \
+    LOCAL_IO_WRITE_STR(", line ");                                      \
+    LOCAL_IO_WRITE_STR(TOSTRING(__LINE__));                             \
+    LOCAL_IO_WRITE_STR(": ");                                           \
+    LOCAL_IO_WRITE_STR(# _F);                                           \
+    LOCAL_IO_WRITE_STR("(");                                            \
+    LOCAL_IO_WRITE_FPR(_F);                                             \
+    LOCAL_IO_WRITE_STR(") != ");                                        \
+    LOCAL_IO_WRITE_STR(# _I);                                           \
+    LOCAL_IO_WRITE_STR("\n");                                           \
+    li TESTNUM, 100;                                                    \
+    RVTEST_FAIL;                                                        \
+20003:
+
+// _D = DFPR
+// _R = GPR
+// _I = Immediate
+#define RVTEST_IO_ASSERT_DFPR_EQ(_D, _R, _I)                            \
+    fmv.x.d     t0, _D;                                                 \
+    beq         _R, t0, 20005f;                                         \
+    LOCAL_IO_WRITE_STR("Assertion violation: file ");                   \
+    LOCAL_IO_WRITE_STR(__FILE__);                                       \
+    LOCAL_IO_WRITE_STR(", line ");                                      \
+    LOCAL_IO_WRITE_STR(TOSTRING(__LINE__));                             \
+    LOCAL_IO_WRITE_STR(": ");                                           \
+    LOCAL_IO_WRITE_STR(# _D);                                           \
+    LOCAL_IO_WRITE_STR("(");                                            \
+    LOCAL_IO_WRITE_DFPR(_D);                                            \
+    LOCAL_IO_WRITE_STR(") != ");                                        \
+    LOCAL_IO_WRITE_STR(# _I);                                           \
+    LOCAL_IO_WRITE_STR("\n");                                           \
+    li TESTNUM, 100;                                                    \
+    RVTEST_FAIL;                                                        \
+20005:
+
+// _SP = (volatile register)
+#define LOCAL_IO_WRITE_STR(_STR) RVTEST_IO_WRITE_STR(x31, _STR)
+#define RVTEST_IO_WRITE_STR(_SP, _STR)                                  \
+    LOCAL_IO_PUSH(_SP)                                                  \
+    .section .data.string;                                              \
+20001:                                                                  \
+    .string _STR;                                                       \
+    .section .text;                                                     \
+    la a0, 20001b;                                                      \
+    jal FN_WriteStr;                                                    \
+    LOCAL_IO_POP(_SP)
+
+// generate assertion listing
+#define LOCAL_CHECK() RVTEST_IO_CHECK()
+#define RVTEST_IO_CHECK()                                               \
+    li zero, -1;                                                        \
+
+.section .text
+//
+// FN_WriteStr: Uses a0, t0
+//
+FN_WriteStr:
+    mv          t0, a0;
+10000:
+    lbu         a0, (t0);
+    addi        t0, t0, 1;
+    beq         a0, zero, 10000f;
+    LOCAL_IO_PUTC(a0);
+    j           10000b;
+10000:
+    ret;
+
+//
+// FN_WriteA0: write register a0(x10) (destroys a0(x10), t0-t3(x5-x7, x28))
+//
+FN_WriteA0:
+        mv          t0, a0
+        // determine architectural register width
+        li          a0, -1
+        srli        a0, a0, 31
+        srli        a0, a0, 1
+        bnez        a0, FN_WriteA0_64
+
+FN_WriteA0_32:
+        // reverse register when xlen is 32
+        li          t1, 8
+10000:  slli        t2, t2, 4
+        andi        a0, t0, 0xf
+        srli        t0, t0, 4
+        or          t2, t2, a0
+        addi        t1, t1, -1
+        bnez        t1, 10000b
+        li          t1, 8
+        j           FN_WriteA0_common
+
+FN_WriteA0_64:
+        // reverse register when xlen is 64
+        li          t1, 16
+10000:  slli        t2, t2, 4
+        andi        a0, t0, 0xf
+        srli        t0, t0, 4
+        or          t2, t2, a0
+        addi        t1, t1, -1
+        bnez        t1, 10000b
+        li          t1, 16
+
+FN_WriteA0_common:
+        // write reversed characters
+        li          t0, 10
+10000:  andi        a0, t2, 0xf
+        blt         a0, t0, 10001f
+        addi        a0, a0, 'a'-10
+        j           10002f
+10001:  addi        a0, a0, '0'
+10002:  LOCAL_IO_PUTC(a0)
+        srli        t2, t2, 4
+        addi        t1, t1, -1
+        bnez        t1, 10000b
+        ret
+
+#endif // RVTEST_IO_QUIET
+
+#endif // _COMPLIANCE_IO_H

--- a/riscv-target/ri5cy/compliance_test.h
+++ b/riscv-target/ri5cy/compliance_test.h
@@ -1,0 +1,51 @@
+// RISC-V Compliance Test Header File
+// Copyright (c) 2017, Codasip Ltd. All Rights Reserved.
+// See LICENSE for license details.
+//
+// Description: Common header file for RV32I tests
+
+#ifndef _COMPLIANCE_TEST_H
+#define _COMPLIANCE_TEST_H
+
+#include "riscv_test.h"
+
+//-----------------------------------------------------------------------
+// RV Compliance Macros
+//-----------------------------------------------------------------------
+
+#define TESTUTIL_BASE 0x20000000
+#define TESTUTIL_ADDR_HALT (TESTUTIL_BASE + 0x10)
+#define TESTUTIL_ADDR_BEGIN_SIGNATURE (TESTUTIL_BASE + 0x8)
+#define TESTUTIL_ADDR_END_SIGNATURE (TESTUTIL_BASE + 0xc)
+
+#define RV_COMPLIANCE_HALT                                                    \
+        /* tell simulation about location of begin_signature */               \
+        la t0, begin_signature;                                               \
+        li t1, TESTUTIL_ADDR_BEGIN_SIGNATURE;                                 \
+        sw t0, 0(t1);                                                         \
+        /* tell simulation about location of end_signature */                 \
+        la t0, end_signature;                                                 \
+        li t1, TESTUTIL_ADDR_END_SIGNATURE;                                   \
+        sw t0, 0(t1);                                                         \
+        /* dump signature and terminate simulation */                         \
+        li t0, 1;                                                             \
+        li t1, TESTUTIL_ADDR_HALT;                                            \
+        sw t0, 0(t1);                                                         \
+        RVTEST_PASS                                                           \
+
+#define RV_COMPLIANCE_RV32M                                                   \
+        RVTEST_RV32M                                                          \
+
+#define RV_COMPLIANCE_CODE_BEGIN                                              \
+        RVTEST_CODE_BEGIN                                                     \
+
+#define RV_COMPLIANCE_CODE_END                                                \
+        RVTEST_CODE_END                                                       \
+
+#define RV_COMPLIANCE_DATA_BEGIN                                              \
+        RVTEST_DATA_BEGIN                                                     \
+
+#define RV_COMPLIANCE_DATA_END                                                \
+        RVTEST_DATA_END                                                       \
+
+#endif

--- a/riscv-target/ri5cy/device/rv32imc/Makefile.include
+++ b/riscv-target/ri5cy/device/rv32imc/Makefile.include
@@ -1,0 +1,32 @@
+RI5CY       = $(ROOTDIR)/riscv-target/ri5cy/device/rv32imc
+LDSCRIPT    = $(RI5CY)/link.ld
+TRAPHANDLER = $(RI5CY)/handler.S
+DEFINES     = -DPRIV_MISA_S=0 -DPRIV_MISA_U=0 -DTRAPHANDLER="\"$(TRAPHANDLER)\""
+
+TARGET_SIM ?= vsim -work $(VSIM_WORK)
+
+RUN_TARGET=\
+    $(TARGET_SIM) -c -quiet tb_top_vopt -do 'run -all; exit -f' \
+        +firmware=$(work_dir_isa)/$<.bin \
+	+maxcycles=10000 \
+	+signature=$(work_dir_isa)/$(*).signature.output
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_OBJCOPY  ?= $(RISCV_PREFIX)objcopy
+RISCV_NM       ?= $(RISCV_PREFIX)nm
+RISCV_READELF  ?= $(RISCV_PREFIX)readelf
+RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+
+COMPILE_TARGET=\
+	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
+		-I$(ROOTDIR)/riscv-test-env/ \
+		-I$(ROOTDIR)/riscv-test-env/p/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+		$(DEFINES) -T$(LDSCRIPT) $$< \
+		-o $(work_dir_isa)/$$@; \
+    $$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump; \
+    $$(RISCV_READELF) -a $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.readelf; \
+    $$(RISCV_NM) $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.nm; \
+    $$(RISCV_OBJCOPY) -O verilog $(work_dir_isa)/$$@ $(work_dir_isa)/$$@.bin;

--- a/riscv-target/ri5cy/device/rv32imc/handler.S
+++ b/riscv-target/ri5cy/device/rv32imc/handler.S
@@ -1,0 +1,35 @@
+.section .text.trap;
+.align  4;
+
+_trap_start:
+    j _trap_exception
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+    j _int_exc
+
+
+// This could be exception or user interrupt
+// 0xb is the environment call to indicate the end
+_trap_exception:
+    csrr a0, mcause;
+    addi a1, zero, 0xb
+    beq a0, a1, 1f
+    la a1, begin_signature
+    sw a0, 0(a1);
+1:
+    la a0, write_tohost;
+    jr a0;
+
+_int_exc:
+    la a0, write_tohost;
+    jr a0;
+

--- a/riscv-target/ri5cy/device/rv32imc/link.ld
+++ b/riscv-target/ri5cy/device/rv32imc/link.ld
@@ -1,0 +1,28 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS
+{
+
+  . = 0x00000000;
+  .text.trap : { *(.text.trap) }
+
+  . = 0x00000080;
+  .text.init : { *(.text.init) }
+
+  . = ALIGN(0x1000);
+  .tohost : { *(.tohost) }
+
+  . = ALIGN(0x1000);
+  .text : { *(.text) }
+  _etext = .;
+
+  . = ALIGN(0x1000);
+  .data : { *(.data) }
+  .data.string : { *(.data.string)}
+  _edata = .;
+
+  .bss : { *(.bss) }
+  _end = .;
+
+}


### PR DESCRIPTION
Add RI5CY as a target for the compliance tests. I don't think I did do anything surprising. Most files (`compliance_test.h`, `handler.S`, `Makefile.include`) are reused from the `ibex` port.
`compliance_io.h` is from `riscvOVPsim` with an altered `LOCAL_IO_PUTC(_R) ` function.

The testbench that runs the program is in RI5CY's [tree](https://github.com/pulp-platform/riscv/tree/master/tb/core). Relevant PR: https://github.com/pulp-platform/riscv/pull/138