### PR TITLE
Update I-MISALIGN_JMP-01.S to reflect ratified CSR

### DIFF
--- a/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S
+++ b/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S
@@ -279,12 +279,12 @@ RV_COMPLIANCE_CODE_BEGIN
     # Exception handler
 _trap_handler:
     # increment return address
-    csrr    x30, mbadaddr
+    csrr    x30, mtval
     addi    x30, x30, -2
     csrw    mepc, x30
 
     # store low bits of mbadaddr
-    csrr    x30, mbadaddr
+    csrr    x30, mtval
     andi    x30, x30, 3
     sw      x30, 0(x1)
 


### PR DESCRIPTION
As per 3.1.17 Machine Trap Value (mtval) Register of the privileged spec:
"The mtval register replaces the mbadaddr register in the previous specification. In addition
to providing bad addresses, the register can now provide the bad instruction that triggered an
illegal instruction trap"