### PR TITLE
Ibex: Write instruction trace into log file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-10-07 Philipp Wagner <phw@lowrisc.org>
+    * When executing the test suite, Ibex always writes an instruction
+      log. Update the Makefile to write it to a test-specific location
+      (next to all other log files).
+    * On Ibex, provide an additional .objdump-noalias disassembly file
+      with no aliases and numeric register names (instead of ABI names).
+      This file matches the Ibex trace and can be used to debug the test
+      runs.
+
 2019-08-29 Robert Balas <balasr@iis.ee.ethz.ch>
     * Added support for using RI5CY as a target.
     * Added subdirectory riscv-target/ri5cy

--- a/riscv-target/ibex/device/rv32imc/Makefile.include
+++ b/riscv-target/ibex/device/rv32imc/Makefile.include
@@ -9,6 +9,7 @@ RUN_TARGET=\
     $(TARGET_SIM) \
         --term-after-cycles=100000 \
         --raminit=$(work_dir_isa)/$<.vmem \
+        +ibex_tracer_file_base=$(work_dir_isa)/$(*)_ibex_trace \
         > $(work_dir_isa)/$(*).stdout \
         2> $(work_dir_isa)/$@; \
         grep "^SIGNATURE: " $(work_dir_isa)/$(*).stdout | sed 's/SIGNATURE: 0x//' \
@@ -30,8 +31,8 @@ COMPILE_TARGET=\
 		$(DEFINES) -T$(LDSCRIPT) $$< \
 		-o $(work_dir_isa)/$$@; \
     $$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump; \
+    $$(RISCV_OBJDUMP) -Mnumeric -Mno-aliases -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump-noalias; \
     $$(RISCV_READELF) -a $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.readelf; \
     $$(RISCV_NM) $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.nm; \
     $$(RISCV_OBJCOPY) -O binary $(work_dir_isa)/$$@ $(work_dir_isa)/$$@.bin; \
-    srec_cat $(work_dir_isa)/$$@.bin -binary -offset 0x0000 -byte-swap 4 -o $(work_dir_isa)/$$@.vmem -vmem    
-    
+    srec_cat $(work_dir_isa)/$$@.bin -binary -offset 0x0000 -byte-swap 4 -o $(work_dir_isa)/$$@.vmem -vmem


### PR DESCRIPTION
To help debugging test runs, Ibex can now write an instruction trace
into a log file. Create one test-specific log file for each run.

Also create a .objdump-noalias file for each test which calls objdump
with arguments to produce a file closer to what you'd see in the log
files (no ABI names for registers, and no instruction aliases). Using
this file together with the Ibex-generated trace is helpful to debug
test cases.

Depends on https://github.com/lowRISC/ibex/pull/368

Closes lowRISC/ibex#217