### PR TITLE
Ignore case when comparing signature outputs

### DIFF
--- a/riscv-test-env/verify.sh
+++ b/riscv-test-env/verify.sh
@@ -21,7 +21,7 @@ do
         echo    "Check $(printf %16s ${stub}) ... IGNORE"
         continue
     fi
-    diff --strip-trailing-cr ${ref} ${sig} #&> /dev/null
+    diff --ignore-case --strip-trailing-cr ${ref} ${sig} #&> /dev/null
     if [ $? == 0 ]
     then
         echo " ... OK"


### PR DESCRIPTION
VHDL's `hwrite()` function produces values using uppercase hex literals, while the reference signatures are lowercase. Verifying the signatures would thus either require a separate lowercasing step, or the comparisong can simply be done in a case-insensitive manner.