### PR TITLE
Report error in Ibex run target

### DIFF
--- a/riscv-target/ibex/device/rv32imc/Makefile.include
+++ b/riscv-target/ibex/device/rv32imc/Makefile.include
@@ -7,11 +7,12 @@ TARGET_SIM   ?= Vibex_riscv_compliance
 TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
 
 RUN_TARGET=\
-    $(TARGET_SIM) $(TARGET_FLAGS) \
+    echo '' > $(work_dir_isa)/$(*).signature.output; \
+	$(TARGET_SIM) $(TARGET_FLAGS) \
         --term-after-cycles=100000 \
         --raminit=$(work_dir_isa)/$<.vmem \
         > $(work_dir_isa)/$(*).stdout \
-        2> $(work_dir_isa)/$@; \
+        2> $(work_dir_isa)/$@ && \
         grep "^SIGNATURE: " $(work_dir_isa)/$(*).stdout | sed 's/SIGNATURE: 0x//' \
         > $(work_dir_isa)/$(*).signature.output
 

--- a/riscv-test-suite/rv32Zicsr/Makefile
+++ b/riscv-test-suite/rv32Zicsr/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32Zifencei/Makefile
+++ b/riscv-test-suite/rv32Zifencei/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32i/Makefile
+++ b/riscv-test-suite/rv32i/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32im/Makefile
+++ b/riscv-test-suite/rv32im/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32imc/Makefile
+++ b/riscv-test-suite/rv32imc/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32mi/Makefile
+++ b/riscv-test-suite/rv32mi/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32si/Makefile
+++ b/riscv-test-suite/rv32si/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32ua/Makefile
+++ b/riscv-test-suite/rv32ua/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32uc/Makefile
+++ b/riscv-test-suite/rv32uc/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32ud/Makefile
+++ b/riscv-test-suite/rv32ud/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32uf/Makefile
+++ b/riscv-test-suite/rv32uf/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv32ui/Makefile
+++ b/riscv-test-suite/rv32ui/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.log: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv64i/Makefile
+++ b/riscv-test-suite/rv64i/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.out64: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template

--- a/riscv-test-suite/rv64im/Makefile
+++ b/riscv-test-suite/rv64im/Makefile
@@ -30,7 +30,7 @@ endif
 # Build and run assembly tests
 
 %.out64: %.elf
-	$(RUN_TARGET)
+	-$(RUN_TARGET)
 
 
 define compile_template


### PR DESCRIPTION
Thanks for the feedback in #70 @allenjbaum 
I created this PR which reflects the description / improvement detailed in the issue.

The current output for an error in the execution of the Ibex target is
not reported. All tests are executed and at the verification stage a
difference in the output signatures will result in a failure of the test
case.
As no error of `RUN_TARGET` is produced, it is difficult to investigate
the actual problem.

This change will allow `make` to report an error but continue the
execution of the following tests.
As the output of a test case now shows that an error occurred, it is
easier to find the cause for a failed test if an error happened in the
execution of the target.

Closes riscv/riscv-compliance#70