### PR TITLE
Fix bad expected values in I-SRL-01 asserts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-02-06 Jake Taylor <yupferris@gmail.com>
+    * [Issue #81] fixing rv32i/I-SRL-01.S test
+
 2019-11-05 Lee Moore <moore@imperas.com>
     * Restructured RV32I to move Zicsr and Zifencei into their own suites
 

--- a/riscv-test-suite/rv32i/src/I-SRL-01.S
+++ b/riscv-test-suite/rv32i/src/I-SRL-01.S
@@ -46,7 +46,7 @@ RV_COMPLIANCE_CODE_BEGIN
 	TEST_RR_OP(srl, x0, x31, x16, 0x0, -0x1, 0x0, x5, 0, x6)   # Testcase 0
 	TEST_RR_OP(srl, x1, x30, x15, 0x1, 0x1, 0x0, x5, 4, x6)   # Testcase 1
 	TEST_RR_OP(srl, x2, x29, x14, 0x0, 0x0, -0x1, x5, 8, x6)   # Testcase 2
-	TEST_RR_OP(srl, x3, x28, x13, 0xf0000000, 0x7ff, 0x4, x5, 12, x6)   # Testcase 3
+	TEST_RR_OP(srl, x3, x28, x13, 0x7f, 0x7ff, 0x4, x5, 12, x6)   # Testcase 3
 	TEST_RR_OP(srl, x4, x27, x12, 0x0, 0x0, 0x8, x5, 16, x6)   # Testcase 4
 
 
@@ -57,9 +57,9 @@ RV_COMPLIANCE_CODE_BEGIN
     # address for test results
 	la	x1, test_2_res
 
-	TEST_RR_OP(srl, x5, x26, x11, 0x1000, 0x800, 0x1f, x1, 0, x2)   # Testcase 5
-	TEST_RR_OP(srl, x6, x25, x10, 0x43210000, 0x7654321, 0x10, x1, 4, x2)   # Testcase 6
-	TEST_RR_OP(srl, x7, x24, x9, 0xfffffffe, 0x7fffffff, -0x1, x1, 8, x2)   # Testcase 7
+	TEST_RR_OP(srl, x5, x26, x11, 0x0, 0x800, 0x1f, x1, 0, x2)   # Testcase 5
+	TEST_RR_OP(srl, x6, x25, x10, 0x765, 0x7654321, 0x10, x1, 4, x2)   # Testcase 6
+	TEST_RR_OP(srl, x7, x24, x9, 0x0, 0x7fffffff, -0x1, x1, 8, x2)   # Testcase 7
 	TEST_RR_OP(srl, x8, x23, x8, 0x1, 0x1, 0x0, x1, 12, x2)   # Testcase 8
 	TEST_RR_OP(srl, x9, x22, x7, 0xffffffff, 0xffffffff, 0x0, x1, 16, x2)   # Testcase 9
 
@@ -71,11 +71,11 @@ RV_COMPLIANCE_CODE_BEGIN
     # address for test results
 	la	x1, test_3_res
 
-	TEST_RR_OP(srl, x10, x21, x6, 0x2468, 0x1234, -0x1, x1, 0, x7)   # Testcase 10
-	TEST_RR_OP(srl, x11, x20, x5, 0x0, 0x80000000, 0x4, x1, 4, x7)   # Testcase 11
-	TEST_RR_OP(srl, x12, x19, x4, 0xcc000000, -0x1234, 0x8, x1, 8, x7)   # Testcase 12
-	TEST_RR_OP(srl, x13, x18, x3, 0xfffffffe, -0x1, 0x1f, x1, 12, x7)   # Testcase 13
-	TEST_RR_OP(srl, x14, x17, x2, 0xf8010000, -0x7ff, 0x10, x1, 16, x7)   # Testcase 14
+	TEST_RR_OP(srl, x10, x21, x6, 0x0, 0x1234, -0x1, x1, 0, x7)   # Testcase 10
+	TEST_RR_OP(srl, x11, x20, x5, 0x8000000, 0x80000000, 0x4, x1, 4, x7)   # Testcase 11
+	TEST_RR_OP(srl, x12, x19, x4, 0xffffed, -0x1234, 0x8, x1, 8, x7)   # Testcase 12
+	TEST_RR_OP(srl, x13, x18, x3, 0x1, -0x1, 0x1f, x1, 12, x7)   # Testcase 13
+	TEST_RR_OP(srl, x14, x17, x2, 0xffff, -0x7ff, 0x10, x1, 16, x7)   # Testcase 14
 
 
 	# ---------------------------------------------------------------------------------------------
@@ -89,7 +89,7 @@ RV_COMPLIANCE_CODE_BEGIN
 	TEST_RR_OP(srl, x16, x15, x0, 0xffffffff, -0x1, 0x0, x2, 4, x3)   # Testcase 16
 	TEST_RR_OP(srl, x17, x14, x31, 0x1, 0x1, 0x0, x2, 8, x3)   # Testcase 17
 	TEST_RR_OP(srl, x18, x13, x30, 0x0, 0x0, -0x1, x2, 12, x3)   # Testcase 18
-	TEST_RR_OP(srl, x19, x12, x29, 0xf0000000, 0x7ff, 0x4, x2, 16, x3)   # Testcase 19
+	TEST_RR_OP(srl, x19, x12, x29, 0x7f, 0x7ff, 0x4, x2, 16, x3)   # Testcase 19
 
 
 	# ---------------------------------------------------------------------------------------------
@@ -100,9 +100,9 @@ RV_COMPLIANCE_CODE_BEGIN
 	la	x1, test_5_res
 
 	TEST_RR_OP(srl, x20, x11, x28, 0x0, 0x0, 0x8, x1, 0, x2)   # Testcase 20
-	TEST_RR_OP(srl, x21, x10, x27, 0x1000, 0x800, 0x1f, x1, 4, x2)   # Testcase 21
-	TEST_RR_OP(srl, x22, x9, x26, 0x43210000, 0x7654321, 0x10, x1, 8, x2)   # Testcase 22
-	TEST_RR_OP(srl, x23, x8, x25, 0xfffffffe, 0x7fffffff, -0x1, x1, 12, x2)   # Testcase 23
+	TEST_RR_OP(srl, x21, x10, x27, 0x0, 0x800, 0x1f, x1, 4, x2)   # Testcase 21
+	TEST_RR_OP(srl, x22, x9, x26, 0x765, 0x7654321, 0x10, x1, 8, x2)   # Testcase 22
+	TEST_RR_OP(srl, x23, x8, x25, 0x0, 0x7fffffff, -0x1, x1, 12, x2)   # Testcase 23
 	TEST_RR_OP(srl, x24, x7, x24, 0x1, 0x1, 0x0, x1, 16, x2)   # Testcase 24
 
 
@@ -114,10 +114,10 @@ RV_COMPLIANCE_CODE_BEGIN
 	la	x1, test_6_res
 
 	TEST_RR_OP(srl, x25, x6, x23, 0xffffffff, 0xffffffff, 0x0, x1, 0, x7)   # Testcase 25
-	TEST_RR_OP(srl, x26, x5, x22, 0x2468, 0x1234, -0x1, x1, 4, x7)   # Testcase 26
-	TEST_RR_OP(srl, x27, x4, x21, 0x0, 0x80000000, 0x4, x1, 8, x7)   # Testcase 27
-	TEST_RR_OP(srl, x28, x3, x20, 0xcc000000, -0x1234, 0x8, x1, 12, x7)   # Testcase 28
-	TEST_RR_OP(srl, x29, x2, x19, 0xfffffffe, -0x1, 0x1f, x1, 16, x7)   # Testcase 29
+	TEST_RR_OP(srl, x26, x5, x22, 0x0, 0x1234, -0x1, x1, 4, x7)   # Testcase 26
+	TEST_RR_OP(srl, x27, x4, x21, 0x8000000, 0x80000000, 0x4, x1, 8, x7)   # Testcase 27
+	TEST_RR_OP(srl, x28, x3, x20, 0xffffed, -0x1234, 0x8, x1, 12, x7)   # Testcase 28
+	TEST_RR_OP(srl, x29, x2, x19, 0x1, -0x1, 0x1f, x1, 16, x7)   # Testcase 29
 
 
 	# ---------------------------------------------------------------------------------------------
@@ -127,7 +127,7 @@ RV_COMPLIANCE_CODE_BEGIN
     # address for test results
 	la	x2, test_7_res
 
-	TEST_RR_OP(srl, x30, x1, x18, 0xf8010000, -0x7ff, 0x10, x2, 0, x3)   # Testcase 30
+	TEST_RR_OP(srl, x30, x1, x18, 0xffff, -0x7ff, 0x10, x2, 0, x3)   # Testcase 30
 	TEST_RR_OP(srl, x31, x0, x17, 0x0, 0x0, -0x1, x2, 4, x3)   # Testcase 31
 
 


### PR DESCRIPTION
These were hidden due to the fact that #define RVTEST_IO_QUIET in compliance_io.h masks out all assertions. The test does appear to produce correct values and a correct signature, however the expected values in the assertions are wrong.

Fixes #81.