### PR TITLE
Support F extension on RV32 sail-riscv-c.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2020-02-07 Prashanth Mundkur <prashanth.mundkur@gmail.com>
+    * Support F extension on RV32 sail-riscv-c.
+
 2019-11-05 Lee Moore <moore@imperas.com>
     * Restructured RV32I to move Zicsr and Zifencei into their own suites
 

--- a/riscv-target/sail-riscv-c/device/rv32uf/Makefile.include
+++ b/riscv-target/sail-riscv-c/device/rv32uf/Makefile.include
@@ -1,0 +1,25 @@
+TARGET_SIM   ?= riscv_sim_RV32
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+RUN_TARGET=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --test-signature=$(work_dir_isa)/$(*).signature.output \
+        $(work_dir_isa)/$< 2> $(work_dir_isa)/$@ 1>&2
+
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles
+
+COMPILE_TARGET=\
+	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) \
+		-I$(ROOTDIR)/riscv-test-env/ \
+		-I$(ROOTDIR)/riscv-test-env/p/ \
+		-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+		-T$(ROOTDIR)/riscv-test-env/p/link.ld $$< \
+		-o $(work_dir_isa)/$$@; \
+	$$(RISCV_OBJDUMP) -D $(work_dir_isa)/$$@ > $(work_dir_isa)/$$@.objdump


### PR DESCRIPTION
Sail-RISCV now has floating-point support in the C emulator: F on RV32, and F/D on RV64.  This adds the rv32uf tests for sail-riscv-c for RV32.