### PR TITLE
remove two duplicate references to a test in a Makefrag file

### DIFF
--- a/riscv-test-suite/rv64i/Makefrag
+++ b/riscv-test-suite/rv64i/Makefrag
@@ -37,7 +37,6 @@ rv64i_sc_tests =    \
 	SRAIW \
 	SRLIW \
 	SLLW \
-	SRAIW \
 
 rv64i_tests = $(addsuffix .elf, $(rv64i_sc_tests))
 

--- a/riscv-test-suite/rv64im/Makefrag
+++ b/riscv-test-suite/rv64im/Makefrag
@@ -32,7 +32,6 @@ rv64im_sc_tests =    \
 	REMW \
 	REMUW \
 	DIVW \
-	REMUW \
 
 rv64im_tests = $(addsuffix .elf, $(rv64im_sc_tests))
 


### PR DESCRIPTION
riscv-test-suite/rv64im/Makefrag: remove duplicate REMUW in value of variable rv64im_sc_tests
riscv-test-suite/rv64i/Makefrag: remove duplicate SRAIW in value of variable rv64i_sc_tests

note: these changes are tested in the 0.1 release, but not in HEAD as something has changed about HEAD and the way I run my tests there is no longer working; that may be a different bug