### PR TITLE
sail-riscv-ocaml: Disable RVC extension on all devices not using it

### DIFF
--- a/riscv-target/sail-riscv-ocaml/device/rv32Zifencei/Makefile.include
+++ b/riscv-target/sail-riscv-ocaml/device/rv32Zifencei/Makefile.include
@@ -6,7 +6,7 @@ ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
 endif
 
 RUN_TARGET=\
-    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 \
+    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 -disable-rvc \
         -test-signature=$(*).signature.output \
         $(<) 2> $@
 

--- a/riscv-target/sail-riscv-ocaml/device/rv32i/Makefile.include
+++ b/riscv-target/sail-riscv-ocaml/device/rv32i/Makefile.include
@@ -6,7 +6,7 @@ ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
 endif
 
 RUN_TARGET=\
-    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 \
+    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 -disable-rvc \
         -test-signature=$(*).signature.output \
         $(<) 2> $@
 

--- a/riscv-target/sail-riscv-ocaml/device/rv32im/Makefile.include
+++ b/riscv-target/sail-riscv-ocaml/device/rv32im/Makefile.include
@@ -6,7 +6,7 @@ ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
 endif
 
 RUN_TARGET=\
-    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 \
+    $(TARGET_SIM) $(TARGET_FLAGS) -isa=rv32 -disable-rvc \
         -test-signature=$(*).signature.output \
         $(<) 2> $@
 


### PR DESCRIPTION
Especially when using the `rv32i` device it might be unexpected that compressed instructions are supported (i.e. 2-byte aligned PCs).