### PR TITLE
xori on 64 bit compiler needs neg number

### DIFF
--- a/riscv-test-suite/rv32i/src/I-RF_x0-01.S
+++ b/riscv-test-suite/rv32i/src/I-RF_x0-01.S
@@ -54,7 +54,7 @@ RV_COMPLIANCE_CODE_BEGIN
     addi    x0, x0, 1
     ori     x0, x0, 0x7F0
     andi    x0, x0, 0x53F
-    xori    x0, x0, 0xFFFFF803
+    xori    x0, x0, -0x7fd
     slli    x0, x0, 5
     srai    x0, x0, 2
     srli    x0, x0, 4


### PR DESCRIPTION
Compiling with 64 bit compiler does not
see a 32 bit number as negative.  Need to
implicitly set this as a negative number so
both 32 and 64 bit compilers behave properly.