### PR TITLE
RI5CY: Fix assembly for clang

### DIFF
--- a/riscv-target/ri5cy/compliance_io.h
+++ b/riscv-target/ri5cy/compliance_io.h
@@ -89,7 +89,7 @@
     jal         FN_WriteA0;						\
 
 #define LOCAL_IO_PUTC(_R)                                               \
-    la          t3, RVTEST_CUSTOM1;					\
+    li          t3, RVTEST_CUSTOM1;					\
     sw          _R, (0)(t3);						\
 
 #define RVTEST_IO_INIT


### PR DESCRIPTION
Older clang versions can't handle it
clang-10.1 works with it and gcc doesn't complain either.

Fixes #108 