### PR TITLE
Update for support of riscvOVPsim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,12 @@ simulate:
 verify:
 	riscv-test-env/verify.sh
 
-cover:
-	riscv-test-env/cover.sh
+postverify:
+ifeq ($(wildcard riscv-target/$(RISCV_TARGET)/postverify.sh),)
+	$(info No post verify script found riscv-target/$(RISCV_TARGET)/postverify.sh)
+else
+	riscv-target/$(RISCV_TARGET)/postverify.sh
+endif
 
 clean:
 	$(MAKE) $(JOBS) \

--- a/Makefile.include
+++ b/Makefile.include
@@ -2,7 +2,7 @@
 export TARGETDIR ?= $(ROOTDIR)/riscv-target
 
 # set XLEN to max supported XLEN. Allowed values are 32 and 64
-export XLEN 							?= 32
+export XLEN               ?= 32
 
 # name of the target. Note a folder of the same name must exist in the TARGETDIR directory
 export RISCV_TARGET       ?= spike
@@ -20,6 +20,6 @@ export RISCV_ASSERT       ?= 0
 
 # set the number of parallel jobs (along with any other arguments) you would like to execute. Note that the target needs to ensure
 # that no common files across jobs are created/overwritten leading to unknown behavior
-JOBS= -j1
+JOBS                      ?= -j1
 
 

--- a/riscv-target/riscvOVPsim/cover.sh
+++ b/riscv-target/riscvOVPsim/cover.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Map RISCV_DEVICE to OVP Variant
+declare -A devMap
+varMap[RV32I]=RV32I
+varMap[RV32M]=RV32IM
+varMap[RV32C]=RV32IMC
+varMap[RV32privilege]=RV32IMC
+varMap[RV32Zifencei]=RV32IMC
+varMap[RV64I]=RV64I
+varMap[RV64M]=RV64IM
+varMap[RV64C]=RV64IMC
+varMap[RV64privilege]=RV64IMC
+varMap[RV64Zifencei]=RV64IMC
+
+# Map RISCV_DEVICE to RISCV CVG
+declare -A cvgMap
+cvgMap[RV32I]=I
+cvgMap[RV32M]=M
+cvgMap[RV32C]=C
+cvgMap[RV32privilege]=privM
+cvgMap[RV32Zifencei]=Zifencei
+cvgMap[RV64I]=I
+cvgMap[RV64M]=M
+cvgMap[RV64C]=C
+cvgMap[RV64privilege]=privM
+cvgMap[RV64Zifencei]=Zifencei
+
+if [ "${COVERTYPE}" == "" ]; then
+    COVERTYPE=basic
+fi
+
+if [ "${RISCV_TARGET}" == "riscvOVPsim" ]; then
+    RISCV_TARGET=riscvOVPsim.exe
+fi
+
+RISCV_DEVICE_ALL=$(ls ${WORK}/rv${XLEN}i_m)
+
+for RISCV_DEV in ${RISCV_DEVICE_ALL}; do
+    echo "Running $RISCV_DEV"
+    RISCV_ISA=rv${XLEN}i_m/${RISCV_DEV}
+    RISCV_CVG=${cvgMap[RV${XLEN}${RISCV_DEV}]}
+    RISCV_VARIANT=${varMap[RV${XLEN}${RISCV_DEV}]}
+
+    if [ -z "${RISCV_VARIANT}" ]; then
+        echo "# Error: Test suite RV${XLEN}${RISCV_DEV} devMap not configured in cover.sh" > work/${RISCV_ISA}/${COVERTYPE}.coverage.run.log
+        exit 1
+    fi
+    if [ -z "${RISCV_CVG}" ]; then
+        echo "# Error: Test suite ${RISCV_DEV} cvgMap not configured in cover.sh" > work/${RISCV_ISA}/${COVERTYPE}.coverage.run.log
+        exit 1
+    fi
+    ${RISCV_TARGET} \
+        --variant ${RISCV_VARIANT}  \
+        --cover ${COVERTYPE} \
+        --countthreshold 1 \
+        --showuncovered \
+        --nosimulation \
+        --extensions ${RISCV_CVG} \
+        --inputfiles work/${RISCV_ISA} \
+        --outputfile work/${RISCV_ISA}/${COVERTYPE}.coverage.yaml \
+        --reportfile work/${RISCV_ISA}/${COVERTYPE}.coverage.txt \
+        ${EXTRA_STR} \
+        --logfile work/${RISCV_ISA}/${COVERTYPE}.coverage.run.log
+    
+done
+
+echo "------------------"
+echo "# Coverage Summary"
+egrep "Unique instructions|Coverage points hit" ${WORK}/rv${XLEN}i_m/*/${COVERTYPE}.coverage.txt
+

--- a/riscv-target/riscvOVPsim/device/rv64i_m/C/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i_m/C/Makefile.include
@@ -1,0 +1,60 @@
+ifeq ($(OS),Windows_NT)
+    ARCH := Windows64
+else
+    ARCH := Linux64
+endif
+
+TARGET_SIM   ?= riscvOVPsim.exe
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+COVERTYPE ?= basic
+
+RUN_CMD=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --variant RV64IMC --program $(<) \
+        --signaturedump --customcontrol \
+        --cover ${COVERTYPE} \
+        --startcover rvtest_code_begin --finishcover rvtest_code_end \
+        --outputfile $(*).${COVERTYPE}.yaml \
+        --extensions RVIC,RV32IC \
+        --override riscvOVPsim/cpu/sigdump/SignatureFile=$(*).signature.output \
+				--override riscvOVPsim/cpu/sigdump/SignatureGranularity=4 \
+        --override riscvOVPsim/cpu/sigdump/ResultReg=3 \
+        --override riscvOVPsim/cpu/simulateexceptions=T \
+        --override riscvOVPsim/cpu/defaultsemihost=F \
+        --logfile $(@) \
+        --override riscvOVPsim/cpu/user_version=2.3 \
+        --override riscvOVPsim/cpu/priv_version=1.11 $(REDIR1); 
+RUN_TARGET=\
+	$(RUN_CMD)
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;

--- a/riscv-target/riscvOVPsim/device/rv64i_m/I/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i_m/I/Makefile.include
@@ -1,0 +1,58 @@
+ifeq ($(OS),Windows_NT)
+    ARCH := Windows64
+else
+    ARCH := Linux64
+endif
+
+TARGET_SIM   ?= riscvOVPsim.exe
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+COVERTYPE ?= basic
+
+RUN_TARGET=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --variant RV64I --program $(<) \
+        --signaturedump --customcontrol \
+        --cover ${COVERTYPE} \
+        --startcover rvtest_code_begin --finishcover rvtest_code_end \
+        --outputfile $(*).${COVERTYPE}.coverage.yaml \
+        --extensions RVI \
+        --override riscvOVPsim/cpu/sigdump/SignatureFile=$(*).signature.output \
+				--override riscvOVPsim/cpu/sigdump/SignatureGranularity=4 \
+        --override riscvOVPsim/cpu/sigdump/ResultReg=3 \
+        --override riscvOVPsim/cpu/simulateexceptions=T \
+        --override riscvOVPsim/cpu/defaultsemihost=F \
+        --logfile $(@) \
+        --override riscvOVPsim/cpu/user_version=2.3 \
+        --override riscvOVPsim/cpu/priv_version=1.11 $(REDIR1); 
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;

--- a/riscv-target/riscvOVPsim/device/rv64i_m/M/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i_m/M/Makefile.include
@@ -1,0 +1,58 @@
+ifeq ($(OS),Windows_NT)
+    ARCH := Windows64
+else
+    ARCH := Linux64
+endif
+
+TARGET_SIM   ?= riscvOVPsim.exe
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+COVERTYPE ?= basic
+
+RUN_TARGET=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --variant RV64IM --program $(<) \
+        --signaturedump --customcontrol \
+        --cover ${COVERTYPE} \
+        --startcover rvtest_code_begin --finishcover rvtest_code_end \
+        --outputfile $(*).${COVERTYPE}.coverage.yaml \
+        --extensions RVM \
+        --override riscvOVPsim/cpu/sigdump/SignatureFile=$(*).signature.output \
+				--override riscvOVPsim/cpu/sigdump/SignatureGranularity=4 \
+        --override riscvOVPsim/cpu/sigdump/ResultReg=3 \
+        --override riscvOVPsim/cpu/simulateexceptions=T \
+        --override riscvOVPsim/cpu/defaultsemihost=F \
+        --logfile $(@) \
+        --override riscvOVPsim/cpu/user_version=2.3 \
+        --override riscvOVPsim/cpu/priv_version=1.11 $(REDIR1); 
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;

--- a/riscv-target/riscvOVPsim/device/rv64i_m/Zifencei/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i_m/Zifencei/Makefile.include
@@ -1,0 +1,57 @@
+ifeq ($(OS),Windows_NT)
+    ARCH := Windows64
+else
+    ARCH := Linux64
+endif
+
+TARGET_SIM   ?= riscvOVPsim.exe
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+COVERTYPE ?= basic
+
+RUN_TARGET=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --variant RV64I --program $(<) \
+        --signaturedump --customcontrol \
+        --cover ${COVERTYPE} \
+        --outputfile $(*).${COVERTYPE}.coverage.yaml \
+        --extensions RVZifencei \
+        --override riscvOVPsim/cpu/sigdump/SignatureFile=$(*).signature.output \
+				--override riscvOVPsim/cpu/sigdump/SignatureGranularity=4 \
+        --override riscvOVPsim/cpu/sigdump/ResultReg=3 \
+        --override riscvOVPsim/cpu/simulateexceptions=T \
+        --override riscvOVPsim/cpu/defaultsemihost=F \
+        --logfile $(@) \
+        --override riscvOVPsim/cpu/user_version=2.3 \
+        --override riscvOVPsim/cpu/priv_version=1.11 $(REDIR1); 
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;

--- a/riscv-target/riscvOVPsim/device/rv64i_m/privilege/Makefile.include
+++ b/riscv-target/riscvOVPsim/device/rv64i_m/privilege/Makefile.include
@@ -1,0 +1,57 @@
+ifeq ($(OS),Windows_NT)
+    ARCH := Windows64
+else
+    ARCH := Linux64
+endif
+
+TARGET_SIM   ?= riscvOVPsim.exe
+TARGET_FLAGS ?= $(RISCV_TARGET_FLAGS)
+ifeq ($(shell command -v $(TARGET_SIM) 2> /dev/null),)
+    $(error Target simulator executable '$(TARGET_SIM)` not found)
+endif
+
+COVERTYPE ?= basic
+
+RUN_TARGET=\
+    $(TARGET_SIM) $(TARGET_FLAGS) \
+        --variant RV64IMC --program $(<) \
+        --signaturedump --customcontrol \
+        --cover ${COVERTYPE} \
+        --outputfile $(*).${COVERTYPE}.coverage.yaml \
+        --extensions RVZicsr \
+        --override riscvOVPsim/cpu/sigdump/SignatureFile=$(*).signature.output \
+				--override riscvOVPsim/cpu/sigdump/SignatureGranularity=4 \
+        --override riscvOVPsim/cpu/sigdump/ResultReg=3 \
+        --override riscvOVPsim/cpu/simulateexceptions=T \
+        --override riscvOVPsim/cpu/defaultsemihost=F \
+        --logfile $(@) \
+        --override riscvOVPsim/cpu/user_version=2.3 \
+        --override riscvOVPsim/cpu/priv_version=1.11 $(REDIR1); 
+
+RISCV_PREFIX   ?= riscv32-unknown-elf-
+RISCV_GCC      ?= $(RISCV_PREFIX)gcc
+RISCV_OBJDUMP  ?= $(RISCV_PREFIX)objdump
+RISCV_GCC_OPTS ?= -g -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles $(RVTEST_DEFINES)
+
+COMPILE_CMD = $$(RISCV_GCC) $(1) $$(RISCV_GCC_OPTS) \
+							-I$(ROOTDIR)/riscv-test-suite/env/ \
+							-I$(TARGETDIR)/$(RISCV_TARGET)/ \
+							-T$(TARGETDIR)/$(RISCV_TARGET)/link.ld \
+							$$(<) -o $$@ 
+OBJ_CMD = $$(RISCV_OBJDUMP) $$@ -D > $$@.objdump; \
+					$$(RISCV_OBJDUMP) $$@ --source > $$@.debug
+
+
+COMPILE_TARGET=\
+				$(COMPILE_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m$$(RISCV_GCC) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ; \
+				$(OBJ_CMD); \
+        if [ $$$$? -ne 0 ] ; \
+                then \
+                echo "\e[31m $$(RISCV_OBJDUMP) failed for target $$(@) \e[39m" ; \
+                exit 1 ; \
+                fi ;

--- a/riscv-target/riscvOVPsim/postverify.sh
+++ b/riscv-target/riscvOVPsim/postverify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# generate coverage
+source $(dirname $0)/cover.sh


### PR DESCRIPTION
Tidied Makefile.include so it is consistent
Re-integrated the 64-bit device targets for riscvOVPsim
Add a postverify target to allow target specific post processing of data