### PR TITLE
Fix NARG macro.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+2021-01-16 S Pawan Kumar <spawan1999@gmail.com>
+  	* Fixed NARGS macro defintion to work correctly. 
+
 2021-01-15 Xiretza <xiretza@xiretza.xyz>
 	* style: Add a missing space to the "OK" message in verify.sh
 

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -542,7 +542,7 @@ rvtest_data_end:
 #define _ARG3(_1ST,_2ND, _3RD, ...) _3RD
 #define _ARG2(_1ST,_2ND, ...) _2ND
 #define _ARG1(_1ST,...) _1ST
-#define NARG(...) _ARG5(__VA_ARGS__,3,2,1,0)
+#define NARG(...) _ARG5(__VA_ARGS__,4,3,2,1,0)
 #define RVTEST_SIGUPD(_BR,_R,...)\
   .if NARG(__VA_ARGS__) == 1;\
     SREG _R,_ARG1(__VA_ARGS__,0)(_BR);\

--- a/riscv-test-suite/env/arch_test.h
+++ b/riscv-test-suite/env/arch_test.h
@@ -542,11 +542,11 @@ rvtest_data_end:
 #define _ARG3(_1ST,_2ND, _3RD, ...) _3RD
 #define _ARG2(_1ST,_2ND, ...) _2ND
 #define _ARG1(_1ST,...) _1ST
-#define NARG(...) _ARG5(__VA_ARGS__,4,3,2,1,0)
+#define NARG(...) _ARG5(__VA_OPT__(__VA_ARGS__,)4,3,2,1,0)
 #define RVTEST_SIGUPD(_BR,_R,...)\
   .if NARG(__VA_ARGS__) == 1;\
     SREG _R,_ARG1(__VA_ARGS__,0)(_BR);\
-    .set offset,_ARG1(__VA_ARGS__,0)+REGWIDTH;\
+    .set offset,_ARG1(__VA_OPT__(__VA_ARGS__,)0)+REGWIDTH;\
   .endif;\
   .if NARG(__VA_ARGS__) == 0;\
     SREG _R,offset(_BR);\


### PR DESCRIPTION
This pull request fixes the NARG macro definition. The previous definition was always evaluated to `length+1` instead of `length` due to a missing argument in the instantiation of the `_ARG5` macro.